### PR TITLE
Delete admin user - password was unknown

### DIFF
--- a/fixtures/users.json
+++ b/fixtures/users.json
@@ -1,20 +1,6 @@
 [
   {
     "model": "users.customuser",
-    "pk": 1,
-    "fields": {
-      "username": "admin",
-      "email": "admin-zeton@mailinator.com",
-      "password": "pbkdf2_sha256$180000$zMLJTx12IxQd$El8/6kDHWtWBm2T9Iut2ujWAYJ7qx5WIZfUx8oaEHjE=",
-      "first_name": "",
-      "last_name": "",
-      "is_staff": true,
-      "is_active": true,
-      "date_joined": "2020-09-29T10:20:55.758Z"
-    }
-  },
-  {
-    "model": "users.customuser",
     "pk": 2,
     "fields": {
       "username": "wojtek",


### PR DESCRIPTION
Deleted admin from fixtures/users.
Password was unknown for us. Even if I put new SHA256 password (hashed 'admin'), this user still couldn't access /admin endpoint:

_Site administration
You don’t have permission to view or edit anything._

![Screenshot from 2021-01-22 10-51-17](https://user-images.githubusercontent.com/44257228/105475951-51184580-5ca0-11eb-985c-52957d6a5fe5.png)
)

Perhaps in fixtures was missing something.

To check this change:
remove docker image and build again (1st terminal: `docker rmi postgres`, then `docker-compose up --build`, 2nd terminal: `make load_data`)
3rd create new admin user `docker-compose exec web python manage.py createsuperuser` - now you may create admin like admin, password admin :)
