### PR TITLE
feat: use "Bearer" as token prefix instead of default "JWT"

### DIFF
--- a/zeton_backend/settings.py
+++ b/zeton_backend/settings.py
@@ -145,6 +145,7 @@ REST_FRAMEWORK = {
 JWT_AUTH = {
     "JWT_RESPONSE_PAYLOAD_HANDLER": "zeton_backend.utils.my_jwt_response_handler",
     "JWT_EXPIRATION_DELTA": datetime.timedelta(minutes=120),
+    "JWT_AUTH_HEADER_PREFIX": "Bearer",
 }
 
 SPECTACULAR_SETTINGS = {


### PR DESCRIPTION
[This package](https://jpadilla.github.io/django-rest-framework-jwt/) has a strange default value of `JWT_AUTH_HEADER_PREFIX` variable. This PR changes that to a more common value of `Bearer`.

![jwt-value](https://github.com/zetonteam/zeton_django/assets/23619042/c4a74efe-e5ba-426b-a88b-736ceb66de80)
