### PR TITLE
Change CircleCI ruff config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,8 @@ jobs:
       - run:
           name: Run static analysis
           command: |
-            ruff check --fix --exit-non-zero-on-fix
-            ruff format
+            ruff check
+            ruff format --check
       - run:
           name: Run tests
           command: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: v0.3.4
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+        args: [--check]


### PR DESCRIPTION
Hi 🙂 I propose to change how ruff behaves on CircleCI:

1) `ruff check` - currently, if issues detected, ruff tires to fix them ([test build 331](https://app.circleci.com/pipelines/github/zetonteam/zeton_django/327/workflows/c08938f6-ff5e-42ff-ae4d-6c65c36f62f1/jobs/331)). I changed it so it doesn't fix the errors on CircleCI, instead it gives a description on detected issues ([test build 333](https://app.circleci.com/pipelines/github/zetonteam/zeton_django/329/workflows/339c1fbf-f264-46b2-b7a8-5c8efbe74e3d/jobs/333)). 
2) `ruff format --check` - currently, if issues detected, ruff tries to format files and passes ([test build 334](https://app.circleci.com/pipelines/github/zetonteam/zeton_django/330/workflows/0397033b-9a29-433f-b188-26e679e6de91/jobs/334?invite=true#step-109-18_43)). I changed it so it displays which files should be changed, and fails ([test build 335](https://app.circleci.com/pipelines/github/zetonteam/zeton_django/331/workflows/0d544fb2-cd1e-4ab2-811e-27ae0812fc00/jobs/335)).

I tested this configuration on a different branch: https://github.com/zetonteam/zeton_django/tree/martasien-token-auth-tests

**Update:** I also introduced the above changes to the pre-commit hook.
