### PR TITLE
Prevent Dependabot from updating Django

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
   - package-ecosystem: "pip"
     # Look for a `requirements.txt` in the `root` directory
     directory: "/"
+    # Ignore updates for the Django package with versions 5
+    ignore:
+      - dependency-name: "django"
+        versions: ["5.*"]
     # Check for updates once a week
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to ignore updates for the Django package to versions 5. 

Please note that Django 4.2 LTS will be supported until April 2026 so I suggest we should use some kind of remainder.