### PR TITLE
Respond with 404 on not found and permission denied

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -146,25 +146,6 @@ class EndpointTestCase(TestCase):
         assert "code" in response_json
         assert "messages" in response_json
 
-    def assert_forbidden(self, response) -> None:
-        """
-        Common set of assertions for forbidden access tests.
-
-        Parameters
-        ----------
-        response
-            Response for a forbidden access request.
-        """
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.headers["Content-Type"] == "application/json"
-        response_json = response.json()
-        assert len(response_json) == 1
-        assert "detail" in response_json
-        assert (
-            response_json["detail"]
-            == "You do not have permission to perform this action."
-        )
-
     def assert_not_found(self, response) -> None:
         """
         Common set of assertions for not found access tests.
@@ -175,12 +156,9 @@ class EndpointTestCase(TestCase):
             Response for a request with not found access request.
         """
         # Result should be the same as for accessing without rights.
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.headers["Content-Type"] == "application/json"
         response_json = response.json()
         assert len(response_json) == 1
         assert "detail" in response_json
-        assert (
-            response_json["detail"]
-            == "You do not have permission to perform this action."
-        )
+        assert response_json["detail"] == "Resource not found or permission denied."

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -23,7 +23,7 @@ class TestPointsGet(EndpointTestCase):
         assert response.status_code == status.HTTP_200_OK
         assert response.headers["Content-Type"] == "application/json"
         response_json = response.json()
-        assert isinstance(response_json, dict)
+        assert isinstance(response_json, list)
 
         # Fixture specific assertions.
         def assert_entry(
@@ -45,12 +45,9 @@ class TestPointsGet(EndpointTestCase):
             assert recv_point["content_type"] == expected_content_type
             assert recv_point["object_id"] == expected_object_id
 
-        assert response_json["count"] == 6
-        # TODO: what are 'previous' and 'next' fields for?
-        results = response_json["results"]
         # Only first two entries are now tested.
         assert_entry(
-            results[0],
+            response_json[0],
             expected_pk=11,
             expected_value=1,
             expected_assigner=1,
@@ -60,7 +57,7 @@ class TestPointsGet(EndpointTestCase):
             expected_object_id=2,
         )
         assert_entry(
-            results[1],
+            response_json[1],
             expected_pk=10,
             expected_value=30,
             expected_assigner=1,
@@ -72,7 +69,7 @@ class TestPointsGet(EndpointTestCase):
 
     def test_Forbidden(self):
         response = self.get(self.NOT_PERMITTED_URL)
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_NotFound(self):
         response = self.get(self.NOT_FOUND_URL)
@@ -177,7 +174,7 @@ class TestPointsPost(EndpointTestCase):
 
     def test_Forbidden(self):
         response = self.post(self.NOT_PERMITTED_URL, self.VALID_POST_PRIZE)
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_NotFound(self):
         response = self.post(self.NOT_FOUND_URL, self.VALID_POST_PRIZE)

--- a/tests/test_prizes.py
+++ b/tests/test_prizes.py
@@ -34,7 +34,7 @@ class TestPrizesGet(EndpointTestCase):
 
     def test_Forbidden(self):
         response = self.get(self.NOT_PERMITTED_URL)
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_NotFound(self):
         response = self.get(self.NOT_FOUND_URL)
@@ -98,7 +98,7 @@ class TestPrizesPost(EndpointTestCase):
 
     def test_Forbidden(self):
         response = self.post(self.NOT_PERMITTED_URL, self.VALID_PRIZE_DATA)
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_NotFound(self):
         response = self.post(self.NOT_FOUND_URL, self.VALID_PRIZE_DATA)
@@ -162,7 +162,7 @@ class TestSinglePrizeGet(EndpointTestCase):
 
     def test_Forbidden(self):
         response = self.get(self.NOT_PERMITTED_URL)
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_StudentNotFound(self):
         response = self.get(self.STUDENT_NOT_FOUND_URL)
@@ -170,14 +170,7 @@ class TestSinglePrizeGet(EndpointTestCase):
 
     def test_PrizeNotFound(self):
         response = self.get(self.PRIZE_NOT_FOUND_URL)
-        # TODO: This test provides results are not caught by 'self.assert_not_found'.
-        # TODO: This is actually more expected result.
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.headers["Content-Type"] == "application/json"
-        response_json = response.json()
-        assert len(response_json) == 1
-        assert "detail" in response_json
-        assert response_json["detail"] == "No Prize matches the given query."
+        self.assert_not_found(response)
 
     def test_NoToken(self):
         response = self.client.get(self.VALID_URL)
@@ -245,7 +238,7 @@ class TestSinglePrizePatch(EndpointTestCase):
 
     def test_Forbidden(self):
         response = self.patch(self.NOT_PERMITTED_URL, "")
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_StudentNotFound(self):
         response = self.patch(self.STUDENT_NOT_FOUND_URL, "")
@@ -253,14 +246,7 @@ class TestSinglePrizePatch(EndpointTestCase):
 
     def test_PrizeNotFound(self):
         response = self.patch(self.PRIZE_NOT_FOUND_URL, "")
-        # TODO: This test provides results are not caught by 'self.assert_not_found'.
-        # TODO: This is actually more expected result.
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.headers["Content-Type"] == "application/json"
-        response_json = response.json()
-        assert len(response_json) == 1
-        assert "detail" in response_json
-        assert response_json["detail"] == "No Prize matches the given query."
+        self.assert_not_found(response)
 
     def test_NoToken(self):
         response = self.client.patch(self.VALID_URL)
@@ -295,18 +281,11 @@ class TestSinglePrizeDelete(EndpointTestCase):
 
         # Try to GET.
         get_response = self.get(self.VALID_URL)
-        # TODO: This test provides results are not caught by 'self.assert_not_found'.
-        # TODO: This is actually more expected result.
-        assert get_response.status_code == status.HTTP_404_NOT_FOUND
-        assert get_response.headers["Content-Type"] == "application/json"
-        response_json = get_response.json()
-        assert len(response_json) == 1
-        assert "detail" in response_json
-        assert response_json["detail"] == "No Prize matches the given query."
+        self.assert_not_found(get_response)
 
     def test_Forbidden(self):
         response = self.delete(self.NOT_PERMITTED_URL)
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_StudentNotFound(self):
         response = self.delete(self.STUDENT_NOT_FOUND_URL)
@@ -314,14 +293,7 @@ class TestSinglePrizeDelete(EndpointTestCase):
 
     def test_PrizeNotFound(self):
         response = self.delete(self.PRIZE_NOT_FOUND_URL)
-        # TODO: This test provides results are not caught by 'self.assert_not_found'.
-        # TODO: This is actually more expected result.
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.headers["Content-Type"] == "application/json"
-        response_json = response.json()
-        assert len(response_json) == 1
-        assert "detail" in response_json
-        assert response_json["detail"] == "No Prize matches the given query."
+        self.assert_not_found(response)
 
     def test_NoToken(self):
         response = self.client.delete(self.VALID_URL)

--- a/tests/test_prizes.py
+++ b/tests/test_prizes.py
@@ -62,7 +62,7 @@ class TestPrizesPost(EndpointTestCase):
     NOT_FOUND_URL = "/api/students/12345/prizes/"
 
     # Valid prize data.
-    VALID_PRIZE_DATA = {"student": "2", "name": "Gry komputerowe", "value": 15}
+    VALID_PRIZE_DATA = {"name": "Gry komputerowe", "value": 15}
 
     def test_Success(self):
         response = self.post(self.VALID_URL, self.VALID_PRIZE_DATA)

--- a/tests/test_students.py
+++ b/tests/test_students.py
@@ -137,7 +137,7 @@ class TestSingleStudentGet(EndpointTestCase):
 
     def test_Forbidden(self):
         response = self.get(self.NOT_PERMITTED_URL)
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_NotFound(self):
         response = self.get(self.NOT_FOUND_URL)
@@ -228,7 +228,7 @@ class TestSingleStudentPatch(EndpointTestCase):
 
     def test_Forbidden(self):
         response = self.patch(self.NOT_PERMITTED_URL, "")
-        self.assert_forbidden(response)
+        self.assert_not_found(response)
 
     def test_NotFound(self):
         response = self.patch(self.NOT_FOUND_URL, "")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -62,7 +62,7 @@ class TestTasksPost(EndpointTestCase):
     TASK_NOT_FOUND_URL = "/api/students/12345/tasks/"
 
     # Valid task data.
-    VALID_TASK_DATA = {"student": "2", "name": "Another new task to do", "value": 21}
+    VALID_TASK_DATA = {"name": "Another new task to do", "value": 21}
 
     def test_Success(self):
         response = self.post(self.VALID_URL, self.VALID_TASK_DATA)

--- a/users/permissions.py
+++ b/users/permissions.py
@@ -1,5 +1,10 @@
-from users.models import Role
+from users.models import Role, Caregiver
 from rest_framework import permissions
+
+
+class IsUserCaregiver(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return Caregiver.objects.filter(user_id=request.user.id).exists()
 
 
 class HasUserAccessToStudent(permissions.BasePermission):
@@ -7,13 +12,3 @@ class HasUserAccessToStudent(permissions.BasePermission):
         return Role.objects.filter(
             student_id=view.kwargs.get("student_id"), caregiver__user_id=request.user.id
         ).exists()
-
-
-def has_caregiver_access_to_student(caregiver_id, student_id) -> bool:
-    # TODO:
-    # This permission is currently not used anywhere-
-    # we could probably remove it.
-
-    return Role.objects.filter(
-        student_id=student_id, caregiver_id=caregiver_id
-    ).exists()

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -106,12 +106,6 @@ class PointSerializer(serializers.ModelSerializer):
         )
 
 
-class PointShortSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Point
-        fields = ["content_type", "object_id"]
-
-
 class RoleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Role

--- a/users/views.py
+++ b/users/views.py
@@ -83,6 +83,13 @@ class _CustomAPIView(APIView):
 
 
 class StudentsResource(_CustomAPIView):
+    """
+    Access students assigned to current user.
+    User must be authenticated and must be a caregiver.
+
+    Adding a new student automatically assigns it to current user.
+    """
+
     serializer_class = StudentSerializer
     permission_classes = [permissions.IsAuthenticated, IsUserCaregiver]
 
@@ -114,6 +121,11 @@ class StudentsResource(_CustomAPIView):
 
 
 class SingleStudentResource(_CustomAPIView):
+    """
+    Access single student assigned to current user.
+    User must be authenticated and must be assigned to the accessed student.
+    """
+
     serializer_class = StudentSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
@@ -133,6 +145,11 @@ class SingleStudentResource(_CustomAPIView):
 
 
 class PrizesResource(_CustomAPIView):
+    """
+    Access prizes assigned to the student.
+    User must be authenticated and must be assigned to the accessed student.
+    """
+
     serializer_class = PrizeSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
@@ -151,6 +168,11 @@ class PrizesResource(_CustomAPIView):
 
 
 class SinglePrizeResource(_CustomAPIView):
+    """
+    Access single prize assigned to the student.
+    User must be authenticated and must be assigned to the accessed student.
+    """
+
     serializer_class = PrizeSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
@@ -176,6 +198,11 @@ class SinglePrizeResource(_CustomAPIView):
 
 
 class TasksResource(_CustomAPIView):
+    """
+    Access tasks assigned to the student.
+    User must be authenticated and must be assigned to the accessed student.
+    """
+
     serializer_class = TaskSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
@@ -194,6 +221,11 @@ class TasksResource(_CustomAPIView):
 
 
 class SingleTaskResource(_CustomAPIView):
+    """
+    Access single task assigned to the student.
+    User must be authenticated and must be assigned to the accessed student.
+    """
+
     serializer_class = TaskSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
@@ -219,6 +251,12 @@ class SingleTaskResource(_CustomAPIView):
 
 
 class PointResource(_CustomAPIView):
+    """
+    Access points assigned to the student.
+    This means claimed prizes and task rewards.
+    User must be authenticated and must be assigned to the accessed student.
+    """
+
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
     def get(self, request, student_id):

--- a/users/views.py
+++ b/users/views.py
@@ -1,14 +1,15 @@
 from django.contrib.contenttypes.models import ContentType
-from drf_spectacular.utils import extend_schema, OpenApiParameter
-from rest_framework import permissions, status, generics
+from rest_framework import permissions, status
 from rest_framework.decorators import api_view
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import (
+    NotAuthenticated,
+    APIException,
+)
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from django.shortcuts import get_object_or_404
 
 from .models import Caregiver, Student, Prize, Task, Point
-from .permissions import HasUserAccessToStudent
+from .permissions import HasUserAccessToStudent, IsUserCaregiver
 
 from .serializers import (
     CustomUserSerializer,
@@ -17,7 +18,6 @@ from .serializers import (
     PrizeSerializer,
     TaskSerializer,
     PointSerializer,
-    PointShortSerializer,
     RoleSerializer,
 )
 
@@ -48,30 +48,54 @@ class UserList(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class StudentsResource(APIView):
+class _NotFoundOrPermissionDenied(APIException):
+    status_code = status.HTTP_404_NOT_FOUND
+    default_detail = "Resource not found or permission denied."
+    default_code = "not_found_or_permission_denied"
+
+
+class _CustomAPIView(APIView):
+    """
+    Modified 'APIView'.
+    Throws 'NotFound' exception when permission is denied.
+    """
+
+    def permission_denied(self, request, message=None, code=None):
+        """
+        If request is not permitted, determine what kind of exception to raise.
+        - 'NotAuthenticated' when user is not authenticated.
+        - 'NotFound' when permission is denied.
+        """
+        if request.authenticators and not request.successful_authenticator:
+            raise NotAuthenticated()
+        raise _NotFoundOrPermissionDenied()
+
+    def get_object(self, model_type, **kwargs):
+        """
+        Return object or raise 404.
+        Replacement for 'get_object_or_404', but with consistent error message.
+        """
+        try:
+            return model_type.objects.get(**kwargs)
+
+        except model_type.DoesNotExist:
+            raise _NotFoundOrPermissionDenied()
+
+
+class StudentsResource(_CustomAPIView):
     serializer_class = StudentSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, IsUserCaregiver]
 
     def get(self, request):
-        user_id = request.user.id
-        try:
-            caregiver = Caregiver.objects.get(user_id=user_id)
-        except Caregiver.DoesNotExist:
-            raise PermissionDenied()
-
+        caregiver = self.get_object(Caregiver, user_id=request.user.id)
         students = caregiver.students.all()
         serializer = StudentSerializer(students, many=True)
 
         return Response(serializer.data)
 
     def post(self, request):
-        try:
-            user_id = request.user.id
-            caregiver_id = Caregiver.objects.get(user_id=user_id).id
-        except Caregiver.DoesNotExist:
-            raise PermissionDenied()
-
         # Create new student entry.
+        caregiver = self.get_object(Caregiver, user_id=request.user.id)
         student_serializer = StudentSerializer(data=request.data)
         student_serializer.is_valid(raise_exception=True)
         student_serializer.save()
@@ -79,7 +103,7 @@ class StudentsResource(APIView):
         # Add a role.
         role_data = {
             "role_name": "caregiver",
-            "caregiver": caregiver_id,
+            "caregiver": caregiver.id,
             "student": student_serializer.data["pk"],
         }
         role_serializer = RoleSerializer(data=role_data)
@@ -89,174 +113,122 @@ class StudentsResource(APIView):
         return Response(student_serializer.data)
 
 
-class SingleStudentResource(APIView):
+class SingleStudentResource(_CustomAPIView):
     serializer_class = StudentSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
     def get(self, request, student_id):
-        student = Student.objects.get(pk=student_id)
+        student = self.get_object(Student, pk=student_id)
         serializer = StudentSerializer(student)
 
         return Response(serializer.data)
 
     def patch(self, request, student_id):
-        student = Student.objects.get(pk=student_id)
+        student = self.get_object(Student, pk=student_id)
         serializer = StudentSerializer(student, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
+
         return Response(serializer.data)
 
 
-class PrizesResource(APIView):
+class PrizesResource(_CustomAPIView):
     serializer_class = PrizeSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
     def get(self, request, student_id):
         prizes = Prize.objects.filter(student_id=student_id)
         serializer = PrizeSerializer(prizes, many=True)
+
         return Response(serializer.data)
 
     def post(self, request, student_id):
         serializer = PrizeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save(student_id=student_id)
+
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
-class SinglePrizeResource(APIView):
+class SinglePrizeResource(_CustomAPIView):
     serializer_class = PrizeSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
     def get(self, request, student_id, prize_id):
-        prize = get_object_or_404(Prize, pk=prize_id, student_id=student_id)
+        prize = self.get_object(Prize, pk=prize_id, student_id=student_id)
         serializer = PrizeSerializer(prize)
+
         return Response(serializer.data)
 
     def patch(self, request, student_id, prize_id):
-        prize = get_object_or_404(Prize, pk=prize_id, student_id=student_id)
+        prize = self.get_object(Prize, pk=prize_id, student_id=student_id)
         serializer = PrizeSerializer(prize, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
+
         return Response(serializer.data)
 
     def delete(self, request, student_id, prize_id):
-        prize = get_object_or_404(Prize, pk=prize_id, student_id=student_id)
+        prize = self.get_object(Prize, pk=prize_id, student_id=student_id)
         prize.delete()
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class TasksResource(APIView):
+class TasksResource(_CustomAPIView):
     serializer_class = TaskSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
     def get(self, request, student_id):
         tasks = Task.objects.filter(student_id=student_id)
         serializer = TaskSerializer(tasks, many=True)
+
         return Response(serializer.data)
 
     def post(self, request, student_id):
         serializer = TaskSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save(student_id=student_id)
+
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
-class SingleTaskResource(APIView):
+class SingleTaskResource(_CustomAPIView):
     serializer_class = TaskSerializer
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
 
     def get(self, request, student_id, task_id):
-        task = get_object_or_404(Task, pk=task_id, student_id=student_id)
+        task = self.get_object(Task, pk=task_id, student_id=student_id)
         serializer = TaskSerializer(task)
+
         return Response(serializer.data)
 
-    def patch(self, request, student_id, task_id):
-        task = get_object_or_404(Task, pk=task_id, student_id=student_id)
+    def patch(self, request, student_id, task_id=None):
+        task = self.get_object(Task, pk=task_id, student_id=student_id)
         serializer = TaskSerializer(task, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
+
         return Response(serializer.data)
 
-    def delete(self, request, student_id, task_id):
-        task = get_object_or_404(Task, pk=task_id, student_id=student_id)
+    def delete(self, request, student_id, task_id=None):
+        task = self.get_object(Task, pk=task_id, student_id=student_id)
         task.delete()
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class PointResource(generics.GenericAPIView):
+class PointResource(_CustomAPIView):
     permission_classes = [permissions.IsAuthenticated, HasUserAccessToStudent]
-    serializer_class = PointShortSerializer
 
-    def get_queryset(self):
-        queryset = Point.objects.filter(student_id=self.kwargs["student_id"])
-        return queryset.order_by("-assignment_date")
-
-    def get_serializer_class(self):
-        if self.request.method == "POST":
-            return PointShortSerializer()
-        else:
-            return PointSerializer
-
-    @extend_schema(
-        # extra parameters added to the schema
-        parameters=[
-            OpenApiParameter(
-                name="page",
-                description="number of page from pagination",
-                required=False,
-                type=int,
-            ),
-            OpenApiParameter(
-                name="page_size",
-                description="number of records in page for pagination",
-                required=False,
-                type=int,
-            ),
-        ],
-        # override default docstring extraction
-        description="Endpoint to generate last records of points of particular student by pagination",
-        # change the auto-generated operation name
-        operation_id=None,
-        # or even completely override what AutoSchema would generate. Provide raw Open API spec as Dict.
-        operation=None,
-    )
     def get(self, request, student_id):
-        user_id = request.user.id
-        try:
-            _ = Caregiver.objects.get(user_id=user_id)
-        except Caregiver.DoesNotExist:
-            raise PermissionDenied()
+        points = Point.objects.filter(student_id=student_id).order_by(
+            "-assignment_date"
+        )
+        serializer = PointSerializer(points, many=True)
 
-        query_set = self.get_queryset()
-        page = self.paginate_queryset(query_set)
+        return Response(serializer.data)
 
-        serializer = self.get_serializer(page, many=True)
-        return self.get_paginated_response(serializer.data)
-
-    @extend_schema(
-        # extra parameters added to the schema
-        request=PointShortSerializer,
-        # parameters=[
-        #     OpenApiParameter(
-        #         name="content_type",
-        #         description="task or prize",
-        #         required=True,
-        #         type=str,
-        #     ),
-        #     OpenApiParameter(
-        #         name="object_id",
-        #         description="task_id or prize_id",
-        #         required=True,
-        #         type=int,
-        #     ),
-        # ],
-        # override default docstring extraction
-        # description="Endpoint to generate last records of points of particular student by pagination",
-        # change the auto-generated operation name
-        # operation_id=None,
-        # or even completely override what AutoSchema would generate. Provide raw Open API spec as Dict.
-        # operation=None,
-    )
     def post(self, request, student_id):
         content_type = request.data.get("content_type")
         object_id = request.data.get("object_id")


### PR DESCRIPTION
Resolve #172 

- Custom exception that informs that resource is either not found or permission is denied.
- `/api/students` now use built-in permissions to detect caregiver permissions.
- Custom `APIView` that throws proper exception on lack of permissions.
- Simplified `PointResource`. No one really could tell why `GenericAPIView` is used.
  - This removed pagination. I assume that once really needed - pagination should be implemented in every endpoint that returns more than one entry.